### PR TITLE
Cigarette Changes

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1166,12 +1166,16 @@
 	product_ads = "Probably not bad for you!;Don't believe the scientists!;It's good for you!;Don't quit, buy more!;Smoke!;Nicotine heaven.;Best cigarettes since 2150.;Award-winning cigs.;Cigars avalible for premium customers.;Best taste in space!"
 	vend_delay = 34
 	icon_state = "cigs"
-	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10,
-					/obj/item/weapon/storage/box/matches = 10,
-					/obj/item/weapon/flame/lighter/random = 4)
-	contraband = list(/obj/item/weapon/flame/lighter/zippo = 4,
-						/obj/item/weapon/storage/fancy/cigar = 5,
-						/obj/item/weapon/storage/fancy/cigarettes/killthroat = 5)
+	products = list(/obj/item/weapon/storage/fancy/cigarettes = 7,
+				/obj/item/weapon/storage/fancy/cigarettes/oblast = 7,
+				/obj/item/weapon/storage/fancy/cigarettes/volga = 7,
+				/obj/item/weapon/storage/fancy/cigarettes/lena = 7,
+				/obj/item/weapon/storage/fancy/cigarettes/severnaya = 7,
+				/obj/item/weapon/storage/fancy/cigarettes/federal = 7,
+				/obj/item/weapon/storage/box/matches = 10,
+				/obj/item/weapon/flame/lighter/random = 4,
+				/obj/item/weapon/flame/lighter/zippo = 4,)
+	contraband = list(/obj/item/weapon/storage/fancy/cigar = 5)
 	prices = list(/obj/item/weapon/storage/fancy/cigarettes = 300,
 					/obj/item/weapon/storage/box/matches = 100,
 					/obj/item/weapon/flame/lighter/random = 150,

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -136,8 +136,8 @@
 //CIG PACK//
 ////////////
 /obj/item/weapon/storage/fancy/cigarettes
-	name = "cigarette packet"
-	desc = "The most popular brand of Space Cigarettes, sponsors of the Space Olympics."
+	name = "Kholat Pass packet"
+	desc = "A packet of six Kholat Pass cigarettes."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cigpacket"
 	item_state = "cigpacket"
@@ -181,21 +181,35 @@
 	else
 		..()
 
-/obj/item/weapon/storage/fancy/cigarettes/dromedaryco
-	name = "\improper DromedaryCo packet"
-	desc = "A packet of six imported DromedaryCo cancer sticks. A label on the packaging reads, \"Wouldn't a slow death make a change?\""
+/obj/item/weapon/storage/fancy/cigarettes/oblast
+	name = "\improper Oblast Gold packet"
+	desc = "A packet of six Kholat Pass cigarettes."
+	icon_state = "cigpacket"
+	item_state = "cigpacket"
+
+/obj/item/weapon/storage/fancy/cigarettes/volga
+	name = "\improper Volga Imported packet"
+	desc = "A packet of six Volga Imported cigarettes."
+	icon_state = "Bpacket"
+	item_state = "Bpacket"
+
+/obj/item/weapon/storage/fancy/cigarettes/lena
+	name = "\improper Lena Sunrise packet"
+	desc = "A packet of six Lena Sunrise cigarettes."
+	icon_state = "Bpacket"
+	item_state = "Bpacket"
+
+/obj/item/weapon/storage/fancy/cigarettes/severnaya
+	name = "\improper Severnaya Special packet"
+	desc = "A packet of six Severnaya Special cigarettes."
 	icon_state = "Dpacket"
 	item_state = "Dpacket"
 
-/obj/item/weapon/storage/fancy/cigarettes/killthroat
-	name = "\improper AcmeCo packet"
-	desc = "A packet of six AcmeCo cigarettes. For those who somehow want to obtain the record for the most amount of cancerous tumors."
-	icon_state = "Bpacket"
-	item_state = "Bpacket" //Doesn't have an inhand state, but neither does dromedary, so, ya know..
-
-/obj/item/weapon/storage/fancy/cigarettes/killthroat/Initialize()
-	. = ..()
-	fill_cigarre_package(src, list("fuel" = 15))
+/obj/item/weapon/storage/fancy/cigarettes/federal
+	name = "\improper Federal Star packet"
+	desc = "A packet of six Federal Star cigarettes."
+	icon_state = "Dpacket"
+	item_state = "Dpacket"
 
 /obj/item/weapon/storage/fancy/cigar
 	name = "cigar case"

--- a/code/modules/cargo/packs_hospitality.dm
+++ b/code/modules/cargo/packs_hospitality.dm
@@ -166,7 +166,7 @@
 					/obj/item/weapon/reagent_containers/food/drinks/flask/barflask,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/patron,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/goldschlager,
-					/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
+					/obj/item/weapon/storage/fancy/cigarettes/oblast,
 					/obj/item/weapon/lipstick/jade,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/small/ale,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/small/ale,

--- a/code/modules/economy/price_list.dm
+++ b/code/modules/economy/price_list.dm
@@ -942,23 +942,23 @@
 /obj/item/weapon/storage/fancy/cigarettes
 	price_tag = 150
 
-/obj/item/weapon/storage/fancy/cigarettes/luckystars
+/obj/item/weapon/storage/fancy/cigarettes/oblast
+	price_tag = 160
+
+/obj/item/weapon/storage/fancy/cigarettes/volga
 	price_tag = 170
 
-/obj/item/weapon/storage/fancy/cigarettes/jerichos
-	price_tag = 220
-
-/obj/item/weapon/storage/fancy/cigarettes/menthols
+/obj/item/weapon/storage/fancy/cigarettes/lena
 	price_tag = 180
+
+/obj/item/weapon/storage/fancy/cigarettes/severnaya
+	price_tag  = 190
+
+/obj/item/weapon/storage/fancy/cigarettes/federal
+	price_tag = 200
 
 /obj/item/weapon/storage/fancy/cigar
 	price_tag = 270
-
-/obj/item/weapon/storage/fancy/cigarettes/carcinomas
-	price_tag  = 230
-
-/obj/item/weapon/storage/fancy/cigarettes/professionals
-	price_tag = 250
 
 /obj/item/weapon/storage/box/matches
 	price_tag = 10

--- a/maps/CEVEris/_Nadezhda_Colony_Underground.dmm
+++ b/maps/CEVEris/_Nadezhda_Colony_Underground.dmm
@@ -6874,7 +6874,7 @@
 "cCj" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; pixel_y = 0},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/techmaint,/area/nadezhda/engineering/construction)
 "cCk" = (/obj/structure/bed/chair/wood,/turf/simulated/floor/carpet/oracarpet,/area/nadezhda/crew_quarters/bar)
 "cCl" = (/obj/structure/table/marble,/turf/simulated/floor/tiled/steel/gray_perforated,/area/nadezhda/crew_quarters/bar)
-"cCm" = (/obj/structure/table/marble,/obj/item/weapon/storage/fancy/cigarettes/professionals,/turf/simulated/floor/tiled/white/gray_platform,/area/nadezhda/crew_quarters/bar)
+"cCm" = (/obj/structure/table/marble,/obj/item/weapon/storage/fancy/cigarettes/federal,/turf/simulated/floor/tiled/white/gray_platform,/area/nadezhda/crew_quarters/bar)
 "cCn" = (/obj/structure/table/marble,/turf/simulated/floor/tiled/white/gray_platform,/area/nadezhda/crew_quarters/bar)
 "cCo" = (/obj/machinery/cryopod/robot{dir = 4},/obj/effect/floor_decal/industrial/outline/red,/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white/gray_platform,/area/nadezhda/rnd/chargebay)
 "cCp" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating/under,/area/nadezhda/maintenance/undergroundfloor2east)


### PR DESCRIPTION
## About The Pull Request
Changes to the cigarette machine and cigarette packets because I hated it.
## Changelog
-Instead of simply having ten generic cigarette packets, the cigarette machine now has seven packets each of six brands - Kholat Pass, Oblast Gold, Volga Imported, Lena Sunrise, Severnaya Special, and Federal Star.
-A few price changes to make the gaps between cigarette packets less significant so people will actually buy different brands. The cheapest (Kholat Pass) and most expensive (Federal Star) is only a 50 credit difference.
-Removed 'killthroat cigarettes' because they were just a bit weird and unnecessary.
-Shifted zippo lighters from contraband to standard cigarette machine stocks. They're only lighters!
